### PR TITLE
[defect 118513] Enable msgdma interrupts after HW reset

### DIFF
--- a/drivers/dma/altera-msgdma.c
+++ b/drivers/dma/altera-msgdma.c
@@ -728,6 +728,9 @@ static int msgdma_alloc_chan_resources(struct dma_chan *dchan)
 		list_add_tail(&desc->node, &mdev->free_list);
 	}
 
+	/* Enable the DMA controller including interrupts  */
+	iowrite32(MSGDMA_CSR_CTL_GLOBAL_INTR, mdev->csr + MSGDMA_CSR_CONTROL);
+
 	return MSGDMA_DESC_NUM;
 }
 


### PR DESCRIPTION
The aresman module can force an HW reset on FPGA subsystems and the DMAs included in them. To avoid failures after a reset cycle (e.g. after an application crash), the global interrupt mask is reenabled every time a DMA channel is requested.